### PR TITLE
fix: 🚑 addon icons not working if icon options specified

### DIFF
--- a/src/lucodear/dups/fileGenerator.ts
+++ b/src/lucodear/dups/fileGenerator.ts
@@ -11,7 +11,6 @@ import {
   lightColorFileEnding,
   mapSpecificFileIcons,
 } from '../../icons';
-import { getFileConfigHash } from '../../helpers/fileConfig';
 import { lucodearFileIconsPath } from '../constants';
 import { LucodearFileIcon, LucodearFileIcons } from '../model';
 
@@ -175,12 +174,9 @@ export const setFileIconDefinition = (
 
   const obj: Partial<IconConfiguration> = { iconDefinitions: {} };
   if (config.options) {
-    const fileConfigHash = getFileConfigHash(config.options);
-    // if (!Object.hasOwnProperty.call(config.iconDefinitions ?? {}, iconName)) {
     obj.iconDefinitions![`${iconName}${appendix}`] = {
-      iconPath: `${path}${subpath}${iconName}${appendix}${fileConfigHash}.svg`,
+      iconPath: `${path}${subpath}${iconName}${appendix}.svg`,
     };
-    // }
   }
   return obj;
 };

--- a/src/lucodear/dups/folderGenerator.ts
+++ b/src/lucodear/dups/folderGenerator.ts
@@ -16,7 +16,6 @@ import {
   setDefaultFolderIcons,
   setFolderNames,
 } from '../../icons';
-import { getFileConfigHash } from '../../helpers/fileConfig';
 import { lucodearFolderIconsPath } from '../constants';
 import { LucodearFolderIcon, LucodearFolderTheme } from '../model';
 
@@ -114,21 +113,20 @@ const createIconDefinitions = (
   path: string = iconFolderPath
 ) => {
   config = merge({}, config);
-  const fileConfigHash = getFileConfigHash(config.options ?? {});
   const configIconDefinitions = config.iconDefinitions;
 
   const iconName = icon.name;
   const subpath =
     (icon as LucodearFolderIcon).subpath === undefined
       ? ''
-      : `/${(icon as LucodearFolderIcon).subpath}/`;
+      : `${(icon as LucodearFolderIcon).subpath}/`;
 
   if (configIconDefinitions) {
     configIconDefinitions[iconName + appendix] = {
-      iconPath: `${path}${subpath}${iconName}${appendix}${fileConfigHash}.svg`,
+      iconPath: `${path}${subpath}${iconName}${appendix}.svg`,
     };
     configIconDefinitions[`${iconName}${openedFolder}${appendix}`] = {
-      iconPath: `${path}${subpath}${iconName}${openedFolder}${appendix}${fileConfigHash}.svg`,
+      iconPath: `${path}${subpath}${iconName}${openedFolder}${appendix}.svg`,
     };
   }
   return config;


### PR DESCRIPTION
Fixes bug #10 