### PR TITLE
fix: 🚑 error publishing extension due to misconfiguration

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   "module": "./dist/module/index.cjs",
   "types": "./dist/types/module/index.d.ts",
   "sideEffects": false,
-  "files": ["icons", "icons-lc", "dist/material-icons.json"],
   "contributes": {
     "iconThemes": [
       {


### PR DESCRIPTION
# Description

Fixes:

```
Error: Both a .vscodeignore file and a "files" property in package.json were found. VSCE does not support combining both strategies. Either remove the .vscodeignore file or the "files" property in package.json.
Error: Process completed with exit code 1.
```


## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../../CODE_OF_CONDUCT.md) and promise to abide by these rules
