### PR TITLE
fix: 🚑 svgs being renamed even without config changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
         },
         "lucodear-icons.folders.color": {
           "type": "string",
-          "default": "#ffca28",
+          "default": "#90a4ae",
           "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
           "description": "%configuration.folders.color%"
         },


### PR DESCRIPTION
# Description

Fix the issue making svg being renamed in hte .vscode/extensions folder even without any configuration change